### PR TITLE
Changing ssh timeout for deploying openshift

### DIFF
--- a/scripts/deployOpenShift.sh
+++ b/scripts/deployOpenShift.sh
@@ -50,6 +50,8 @@ sed -i -e "s/^#host_key_checking = False/host_key_checking = False/" /etc/ansibl
 sed -i -e "s/^#pty=False/pty=False/" /etc/ansible/ansible.cfg
 sed -i -e "s/^#stdout_callback = skippy/stdout_callback = skippy/" /etc/ansible/ansible.cfg
 
+sed -i -e "s/^#timeout = 10/timeout = 40/" /etc/ansible/ansible.cfg
+
 # Cloning Ansible playbook repository
 ((cd /home/$SUDOUSER && git clone https://github.com/Microsoft/openshift-container-platform-playbooks.git) || (cd openshift-container-platform-playbooks && git pull))
 if [ -d /home/${SUDOUSER}/openshift-container-platform-playbooks ]


### PR DESCRIPTION
Changing ssh timeout for ansible from 10 to 40. Without this, the master node is not able to communicate with other app nodes in the cluster. Details at https://github.com/microsoft/openshift-origin/issues/114#issuecomment-540667022